### PR TITLE
lens: fix issue causing panic on IPFS reads

### DIFF
--- a/lens.go
+++ b/lens.go
@@ -77,6 +77,7 @@ func NewService(opts *ConfigOpts, cfg *config.TemporalConfig) (*Service, error) 
 		return nil, err
 	}
 	return &Service{
+		im: manager,
 		ta: ta,
 		ia: ia,
 		px: px,


### PR DESCRIPTION
Any IPFS reads initialized within the Lens service were causing panics.